### PR TITLE
Create PascalTypeAnalyzer Avalonia app with lexer, parser, analyzer and MVVM UI

### DIFF
--- a/PascalTypeAnalyzer/App.axaml
+++ b/PascalTypeAnalyzer/App.axaml
@@ -1,0 +1,8 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="PascalTypeAnalyzer.App"
+             RequestedThemeVariant="Light">
+  <Application.Styles>
+    <FluentTheme />
+  </Application.Styles>
+</Application>

--- a/PascalTypeAnalyzer/App.axaml.cs
+++ b/PascalTypeAnalyzer/App.axaml.cs
@@ -1,0 +1,29 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using PascalTypeAnalyzer.Application.Analyzer;
+using PascalTypeAnalyzer.Infrastructure.FileSystem;
+using PascalTypeAnalyzer.Presentation.ViewModels;
+using PascalTypeAnalyzer.Presentation.Views;
+
+namespace PascalTypeAnalyzer;
+
+public partial class App : Avalonia.Application
+{
+    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            var analyzerService = new AnalyzerService();
+            var fileService = new FileService();
+            desktop.MainWindow = new MainWindow
+            {
+                DataContext = new MainWindowViewModel(analyzerService, fileService)
+            };
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/PascalTypeAnalyzer/Application/Analyzer/AnalysisResult.cs
+++ b/PascalTypeAnalyzer/Application/Analyzer/AnalysisResult.cs
@@ -1,0 +1,14 @@
+using PascalTypeAnalyzer.Domain.Diagnostics;
+using PascalTypeAnalyzer.Domain.Syntax;
+using PascalTypeAnalyzer.Domain.Tokens;
+
+namespace PascalTypeAnalyzer.Application.Analyzer;
+
+public sealed class AnalysisResult
+{
+    public required bool IsSuccess { get; init; }
+    public required List<Token> Tokens { get; init; }
+    public required SyntaxNode? SyntaxTree { get; init; }
+    public required List<DiagnosticMessage> Diagnostics { get; init; }
+    public required string TreeText { get; init; }
+}

--- a/PascalTypeAnalyzer/Application/Analyzer/AnalyzerService.cs
+++ b/PascalTypeAnalyzer/Application/Analyzer/AnalyzerService.cs
@@ -1,0 +1,53 @@
+using System.Text;
+using PascalTypeAnalyzer.Application.Lexing;
+using PascalTypeAnalyzer.Application.Parsing;
+using PascalTypeAnalyzer.Domain.Diagnostics;
+using PascalTypeAnalyzer.Domain.Syntax;
+
+namespace PascalTypeAnalyzer.Application.Analyzer;
+
+public sealed class AnalyzerService
+{
+    private readonly Lexer _lexer = new();
+
+    public AnalysisResult Analyze(string source)
+    {
+        var (tokens, lexDiagnostics) = _lexer.Lex(source);
+        var parser = new Parser(tokens);
+        var (tree, parseDiagnostics) = parser.Parse();
+
+        var diagnostics = new List<DiagnosticMessage>();
+        diagnostics.AddRange(lexDiagnostics);
+        diagnostics.AddRange(parseDiagnostics);
+
+        if (diagnostics.Count == 0)
+            diagnostics.Add(new DiagnosticMessage(1, 1, "Анализ выполнен успешно.", false));
+
+        return new AnalysisResult
+        {
+            IsSuccess = diagnostics.All(d => !d.IsError),
+            Tokens = tokens,
+            SyntaxTree = tree,
+            Diagnostics = diagnostics,
+            TreeText = BuildTreeText(tree)
+        };
+    }
+
+    private static string BuildTreeText(SyntaxNode? root)
+    {
+        if (root is null) return string.Empty;
+
+        var sb = new StringBuilder();
+        Walk(root, 0);
+        return sb.ToString();
+
+        void Walk(SyntaxNode node, int depth)
+        {
+            sb.Append(' ', depth * 2);
+            sb.Append(node.Name);
+            if (!string.IsNullOrWhiteSpace(node.Value)) sb.Append($": {node.Value}");
+            sb.AppendLine();
+            foreach (var child in node.Children) Walk(child, depth + 1);
+        }
+    }
+}

--- a/PascalTypeAnalyzer/Application/Lexing/Lexer.cs
+++ b/PascalTypeAnalyzer/Application/Lexing/Lexer.cs
@@ -1,0 +1,111 @@
+using PascalTypeAnalyzer.Domain.Diagnostics;
+using PascalTypeAnalyzer.Domain.Tokens;
+
+namespace PascalTypeAnalyzer.Application.Lexing;
+
+public sealed class Lexer
+{
+    private static readonly HashSet<string> StandardTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "integer", "real", "boolean", "char", "string"
+    };
+
+    public (List<Token> Tokens, List<DiagnosticMessage> Diagnostics) Lex(string text)
+    {
+        var tokens = new List<Token>();
+        var diagnostics = new List<DiagnosticMessage>();
+
+        var pos = 0;
+        var line = 1;
+        var column = 1;
+
+        while (pos < text.Length)
+        {
+            var ch = text[pos];
+            if (char.IsWhiteSpace(ch))
+            {
+                Advance(ch, ref pos, ref line, ref column);
+                continue;
+            }
+
+            var startPos = pos;
+            var startLine = line;
+            var startCol = column;
+
+            if (char.IsLetter(ch))
+            {
+                var value = ReadWhile(text, ref pos, ref line, ref column, c => char.IsLetterOrDigit(c) || c == '_');
+                tokens.Add(new Token(GetWordTokenType(value), value, startPos, startLine, startCol));
+                continue;
+            }
+
+            if (char.IsDigit(ch))
+            {
+                var value = ReadWhile(text, ref pos, ref line, ref column, char.IsDigit);
+                tokens.Add(new Token(TokenType.IntegerNumber, value, startPos, startLine, startCol));
+                continue;
+            }
+
+            switch (ch)
+            {
+                case '=': AddSingle(TokenType.Equal, "="); break;
+                case ';': AddSingle(TokenType.Semicolon, ";"); break;
+                case ',': AddSingle(TokenType.Comma, ","); break;
+                case '(': AddSingle(TokenType.LeftParen, "("); break;
+                case ')': AddSingle(TokenType.RightParen, ")"); break;
+                case '[': AddSingle(TokenType.LeftBracket, "["); break;
+                case ']': AddSingle(TokenType.RightBracket, "]"); break;
+                case '.':
+                    if (pos + 1 < text.Length && text[pos + 1] == '.')
+                    {
+                        tokens.Add(new Token(TokenType.Range, "..", startPos, startLine, startCol));
+                        Advance('.', ref pos, ref line, ref column);
+                        Advance('.', ref pos, ref line, ref column);
+                    }
+                    else
+                    {
+                        tokens.Add(new Token(TokenType.Unknown, ".", startPos, startLine, startCol));
+                        diagnostics.Add(new DiagnosticMessage(startLine, startCol, "Одиночная точка '.' недопустима, ожидается '..'."));
+                        Advance('.', ref pos, ref line, ref column);
+                    }
+                    break;
+                default:
+                    tokens.Add(new Token(TokenType.Unknown, ch.ToString(), startPos, startLine, startCol));
+                    diagnostics.Add(new DiagnosticMessage(startLine, startCol, $"Неизвестный символ '{ch}'."));
+                    Advance(ch, ref pos, ref line, ref column);
+                    break;
+            }
+        }
+
+        tokens.Add(new Token(TokenType.EndOfInput, string.Empty, pos, line, column));
+        return (tokens, diagnostics);
+
+        void AddSingle(TokenType type, string value)
+        {
+            tokens.Add(new Token(type, value, startPos, startLine, startCol));
+            Advance(ch, ref pos, ref line, ref column);
+        }
+    }
+
+    private static TokenType GetWordTokenType(string value)
+    {
+        if (value.Equals("type", StringComparison.OrdinalIgnoreCase)) return TokenType.TypeKeyword;
+        if (value.Equals("array", StringComparison.OrdinalIgnoreCase)) return TokenType.ArrayKeyword;
+        if (value.Equals("of", StringComparison.OrdinalIgnoreCase)) return TokenType.OfKeyword;
+        if (StandardTypes.Contains(value)) return TokenType.StandardTypeKeyword;
+        return TokenType.Identifier;
+    }
+
+    private static string ReadWhile(string text, ref int pos, ref int line, ref int column, Func<char, bool> predicate)
+    {
+        var start = pos;
+        while (pos < text.Length && predicate(text[pos])) Advance(text[pos], ref pos, ref line, ref column);
+        return text[start..pos];
+    }
+
+    private static void Advance(char ch, ref int pos, ref int line, ref int column)
+    {
+        pos++;
+        if (ch == '\n') { line++; column = 1; } else { column++; }
+    }
+}

--- a/PascalTypeAnalyzer/Application/Parsing/Parser.cs
+++ b/PascalTypeAnalyzer/Application/Parsing/Parser.cs
@@ -1,0 +1,178 @@
+using PascalTypeAnalyzer.Domain.Diagnostics;
+using PascalTypeAnalyzer.Domain.Syntax;
+using PascalTypeAnalyzer.Domain.Tokens;
+
+namespace PascalTypeAnalyzer.Application.Parsing;
+
+public sealed class Parser
+{
+    private readonly IReadOnlyList<Token> _tokens;
+    private readonly List<DiagnosticMessage> _diagnostics = new();
+    private int _position;
+
+    public Parser(IReadOnlyList<Token> tokens) => _tokens = tokens;
+
+    public (SyntaxNode? Root, List<DiagnosticMessage> Diagnostics) Parse()
+    {
+        var root = ParseTypeSection();
+        return (root, _diagnostics);
+    }
+
+    public SyntaxNode ParseTypeSection()
+    {
+        var node = new SyntaxNode("TypeSection");
+        if (!Match(TokenType.TypeKeyword, "после начала ввода ожидается ключевое слово 'type'.", out var typeToken))
+        {
+            Recover();
+            return node;
+        }
+
+        node.Add(new SyntaxNode("type", typeToken.Value, typeToken));
+
+        while (Current.Type != TokenType.EndOfInput)
+        {
+            var decl = ParseTypeDeclaration();
+            if (decl is not null) node.Add(decl);
+            else Recover();
+        }
+
+        return node;
+    }
+
+    public SyntaxNode? ParseTypeDeclaration()
+    {
+        var node = new SyntaxNode("TypeDeclaration");
+        if (!Match(TokenType.Identifier, "после ключевого слова 'type' ожидается имя типа.", out var id)) return null;
+        node.Add(new SyntaxNode("Identifier", id.Value, id));
+
+        if (!Match(TokenType.Equal, "после имени типа ожидается символ '='.", out var eq)) return null;
+        node.Add(new SyntaxNode("=", eq.Value, eq));
+
+        var typeSpec = ParseTypeSpec();
+        if (typeSpec is null) return null;
+        node.Add(typeSpec);
+
+        if (!Match(TokenType.Semicolon, "описание типа должно заканчиваться символом ';'.", out var semicolon)) return null;
+        node.Add(new SyntaxNode(";", semicolon.Value, semicolon));
+
+        return node;
+    }
+
+    public SyntaxNode? ParseTypeSpec() => Current.Type switch
+    {
+        TokenType.StandardTypeKeyword => ParseStandardType(),
+        TokenType.IntegerNumber => ParseSubrangeType(),
+        TokenType.LeftParen => ParseEnumType(),
+        TokenType.ArrayKeyword => ParseArrayType(),
+        TokenType.Identifier => ConsumeIdentifierType(),
+        _ => ErrorNode("ожидается описание типа (стандартный, интервальный, перечислимый, массив или пользовательский тип).")
+    };
+
+    public SyntaxNode ParseStandardType()
+    {
+        var token = Next();
+        return new SyntaxNode("StandardType", token.Value, token);
+    }
+
+    public SyntaxNode? ParseSubrangeType()
+    {
+        var node = new SyntaxNode("SubrangeType");
+        if (!Match(TokenType.IntegerNumber, "в интервальном типе ожидается левая целая граница.", out var left)) return null;
+        node.Add(new SyntaxNode("Integer", left.Value, left));
+
+        if (!Match(TokenType.Range, "в интервальном типе ожидается знак диапазона '..'.", out var range)) return null;
+        node.Add(new SyntaxNode("Range", range.Value, range));
+
+        if (!Match(TokenType.IntegerNumber, "в интервальном типе ожидается правая целая граница.", out var right)) return null;
+        node.Add(new SyntaxNode("Integer", right.Value, right));
+        return node;
+    }
+
+    public SyntaxNode? ParseEnumType()
+    {
+        var node = new SyntaxNode("EnumType");
+        if (!Match(TokenType.LeftParen, "ожидается '(' для перечислимого типа.", out var leftParen)) return null;
+        node.Add(new SyntaxNode("(", leftParen.Value, leftParen));
+
+        if (!Match(TokenType.Identifier, "в перечислимом типе ожидается идентификатор элемента.", out var id)) return null;
+        node.Add(new SyntaxNode("Identifier", id.Value, id));
+
+        while (Current.Type == TokenType.Comma)
+        {
+            var comma = Next();
+            node.Add(new SyntaxNode(",", comma.Value, comma));
+            if (!Match(TokenType.Identifier, "после запятой ожидается идентификатор элемента перечисления.", out var nextId)) return null;
+            node.Add(new SyntaxNode("Identifier", nextId.Value, nextId));
+        }
+
+        if (!Match(TokenType.RightParen, "ожидается ')' в конце перечислимого типа.", out var rp)) return null;
+        node.Add(new SyntaxNode(")", rp.Value, rp));
+        return node;
+    }
+
+    public SyntaxNode? ParseArrayType()
+    {
+        var node = new SyntaxNode("ArrayType");
+        var array = Next();
+        node.Add(new SyntaxNode("array", array.Value, array));
+        if (!Match(TokenType.LeftBracket, "после ключевого слова 'array' ожидается '['.", out var lb)) return null;
+        node.Add(new SyntaxNode("[", lb.Value, lb));
+
+        var index = ParseIndexType();
+        if (index is null) return null;
+        node.Add(index);
+
+        if (!Match(TokenType.RightBracket, "после типа индекса ожидается ']'.", out var rb)) return null;
+        node.Add(new SyntaxNode("]", rb.Value, rb));
+
+        if (!Match(TokenType.OfKeyword, "после ']' ожидается ключевое слово 'of'.", out var of)) return null;
+        node.Add(new SyntaxNode("of", of.Value, of));
+
+        var nested = ParseTypeSpec();
+        if (nested is null) return null;
+        node.Add(nested);
+        return node;
+    }
+
+    public SyntaxNode? ParseIndexType() => Current.Type switch
+    {
+        TokenType.IntegerNumber => ParseSubrangeType(),
+        TokenType.Identifier => ConsumeIdentifierType(),
+        _ => ErrorNode("в массиве ожидается индексный тип (интервал или имя типа).")
+    };
+
+    private SyntaxNode ConsumeIdentifierType()
+    {
+        var id = Next();
+        return new SyntaxNode("IdentifierType", id.Value, id);
+    }
+
+    private bool Match(TokenType type, string message, out Token token)
+    {
+        token = Current;
+        if (Current.Type == type)
+        {
+            token = Next();
+            return true;
+        }
+
+        _diagnostics.Add(new DiagnosticMessage(Current.Line, Current.Column, message));
+        return false;
+    }
+
+    private SyntaxNode? ErrorNode(string message)
+    {
+        _diagnostics.Add(new DiagnosticMessage(Current.Line, Current.Column, message));
+        return null;
+    }
+
+    private void Recover()
+    {
+        while (Current.Type is not TokenType.Semicolon and not TokenType.TypeKeyword and not TokenType.EndOfInput)
+            Next();
+        if (Current.Type == TokenType.Semicolon) Next();
+    }
+
+    private Token Current => _tokens[Math.Min(_position, _tokens.Count - 1)];
+    private Token Next() => _tokens[Math.Min(_position++, _tokens.Count - 1)];
+}

--- a/PascalTypeAnalyzer/Domain/Diagnostics/DiagnosticMessage.cs
+++ b/PascalTypeAnalyzer/Domain/Diagnostics/DiagnosticMessage.cs
@@ -1,0 +1,6 @@
+namespace PascalTypeAnalyzer.Domain.Diagnostics;
+
+public sealed record DiagnosticMessage(int Line, int Column, string Message, bool IsError = true)
+{
+    public override string ToString() => $"{(IsError ? "Ошибка" : "Инфо")} в строке {Line}, столбце {Column}: {Message}";
+}

--- a/PascalTypeAnalyzer/Domain/Syntax/SyntaxNode.cs
+++ b/PascalTypeAnalyzer/Domain/Syntax/SyntaxNode.cs
@@ -1,0 +1,20 @@
+using PascalTypeAnalyzer.Domain.Tokens;
+
+namespace PascalTypeAnalyzer.Domain.Syntax;
+
+public sealed class SyntaxNode
+{
+    public string Name { get; }
+    public string? Value { get; }
+    public Token? Token { get; }
+    public List<SyntaxNode> Children { get; } = new();
+
+    public SyntaxNode(string name, string? value = null, Token? token = null)
+    {
+        Name = name;
+        Value = value;
+        Token = token;
+    }
+
+    public void Add(SyntaxNode child) => Children.Add(child);
+}

--- a/PascalTypeAnalyzer/Domain/Tokens/Token.cs
+++ b/PascalTypeAnalyzer/Domain/Tokens/Token.cs
@@ -1,0 +1,8 @@
+namespace PascalTypeAnalyzer.Domain.Tokens;
+
+public sealed record Token(
+    TokenType Type,
+    string Value,
+    int Position,
+    int Line,
+    int Column);

--- a/PascalTypeAnalyzer/Domain/Tokens/TokenType.cs
+++ b/PascalTypeAnalyzer/Domain/Tokens/TokenType.cs
@@ -1,0 +1,21 @@
+namespace PascalTypeAnalyzer.Domain.Tokens;
+
+public enum TokenType
+{
+    TypeKeyword,
+    ArrayKeyword,
+    OfKeyword,
+    StandardTypeKeyword,
+    Identifier,
+    IntegerNumber,
+    Equal,
+    Semicolon,
+    Comma,
+    LeftParen,
+    RightParen,
+    LeftBracket,
+    RightBracket,
+    Range,
+    EndOfInput,
+    Unknown
+}

--- a/PascalTypeAnalyzer/Infrastructure/FileSystem/FileService.cs
+++ b/PascalTypeAnalyzer/Infrastructure/FileSystem/FileService.cs
@@ -1,0 +1,44 @@
+using System.Text;
+using Avalonia.Platform.Storage;
+
+namespace PascalTypeAnalyzer.Infrastructure.FileSystem;
+
+public sealed class FileService
+{
+    public async Task<(string? Path, string? Content)> OpenFileAsync(IStorageProvider storageProvider)
+    {
+        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Открыть Pascal-файл",
+            AllowMultiple = false,
+            FileTypeFilter = new[] { new FilePickerFileType("Текст") { Patterns = new[] { "*.txt", "*.pas" } } }
+        });
+
+        var file = files.FirstOrDefault();
+        if (file is null) return (null, null);
+
+        await using var stream = await file.OpenReadAsync();
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        return (file.Path.LocalPath, await reader.ReadToEndAsync());
+    }
+
+    public async Task<string?> SaveFileAsAsync(IStorageProvider storageProvider, string content)
+    {
+        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Сохранить файл",
+            SuggestedFileName = "types.pas",
+            FileTypeChoices = new[] { new FilePickerFileType("Pascal") { Patterns = new[] { "*.pas", "*.txt" } } }
+        });
+
+        if (file is null) return null;
+        await using var stream = await file.OpenWriteAsync();
+        stream.SetLength(0);
+        await using var writer = new StreamWriter(stream, Encoding.UTF8);
+        await writer.WriteAsync(content);
+        return file.Path.LocalPath;
+    }
+
+    public async Task SaveToPathAsync(string path, string content)
+        => await File.WriteAllTextAsync(path, content, Encoding.UTF8);
+}

--- a/PascalTypeAnalyzer/PascalTypeAnalyzer.csproj
+++ b/PascalTypeAnalyzer/PascalTypeAnalyzer.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.1.7" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.1.7" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.1.7" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.7" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.7" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+  </ItemGroup>
+</Project>

--- a/PascalTypeAnalyzer/Presentation/ViewModels/MainWindowViewModel.cs
+++ b/PascalTypeAnalyzer/Presentation/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,144 @@
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PascalTypeAnalyzer.Application.Analyzer;
+using PascalTypeAnalyzer.Domain.Diagnostics;
+using PascalTypeAnalyzer.Domain.Tokens;
+using PascalTypeAnalyzer.Infrastructure.FileSystem;
+
+namespace PascalTypeAnalyzer.Presentation.ViewModels;
+
+public partial class MainWindowViewModel : ViewModelBase
+{
+    private readonly AnalyzerService _analyzer;
+    private readonly FileService _fileService;
+
+    [ObservableProperty] private string _sourceText = "type TAge = integer;\nTIndex = 1..10;\nTColor = (red, green, blue);\nTIntArray = array[1..10] of integer;";
+    [ObservableProperty] private string _treeText = string.Empty;
+    [ObservableProperty] private string _status = "Готов к анализу";
+    [ObservableProperty] private string _currentFilePath = "Новый файл";
+    [ObservableProperty] private int _errorCount;
+
+    public ObservableCollection<SyntaxTreeNodeViewModel> SyntaxTreeNodes { get; } = new();
+    public ObservableCollection<DiagnosticMessage> Diagnostics { get; } = new();
+    public ObservableCollection<Token> Tokens { get; } = new();
+
+    public ICommand NewCommand { get; }
+    public ICommand OpenCommand { get; }
+    public ICommand SaveCommand { get; }
+    public ICommand SaveAsCommand { get; }
+    public ICommand AnalyzeCommand { get; }
+    public ICommand HelpCommand { get; }
+    public ICommand AboutCommand { get; }
+    public ICommand ExitCommand { get; }
+    public ICommand UndoCommand { get; }
+    public ICommand CutCommand { get; }
+    public ICommand CopyCommand { get; }
+    public ICommand PasteCommand { get; }
+    public ICommand SelectAllCommand { get; }
+
+    public MainWindowViewModel(AnalyzerService analyzer, FileService fileService)
+    {
+        _analyzer = analyzer;
+        _fileService = fileService;
+
+        NewCommand = new RelayCommand(NewFile);
+        OpenCommand = new AsyncRelayCommand<Window?>(OpenFileAsync);
+        SaveCommand = new AsyncRelayCommand<Window?>(SaveFileAsync);
+        SaveAsCommand = new AsyncRelayCommand<Window?>(SaveFileAsAsync);
+        AnalyzeCommand = new RelayCommand(RunAnalysis);
+        HelpCommand = new AsyncRelayCommand<Window?>(ShowHelpAsync);
+        AboutCommand = new AsyncRelayCommand<Window?>(ShowAboutAsync);
+        ExitCommand = new RelayCommand<Window?>(w => w?.Close());
+        UndoCommand = new RelayCommand(() => Status = "Отмена доступна через системные сочетания клавиш.");
+        CutCommand = new RelayCommand(() => Status = "Вырезать: используйте Cmd/Ctrl+X.");
+        CopyCommand = new RelayCommand(() => Status = "Копировать: используйте Cmd/Ctrl+C.");
+        PasteCommand = new RelayCommand(() => Status = "Вставить: используйте Cmd/Ctrl+V.");
+        SelectAllCommand = new RelayCommand(() => Status = "Выделить все: используйте Cmd/Ctrl+A.");
+    }
+
+    private void NewFile()
+    {
+        SourceText = string.Empty;
+        CurrentFilePath = "Новый файл";
+        Status = "Создан новый файл";
+    }
+
+    private async Task OpenFileAsync(Window? window)
+    {
+        if (window?.StorageProvider is null) return;
+        var result = await _fileService.OpenFileAsync(window.StorageProvider);
+        if (result.Content is null) return;
+
+        SourceText = result.Content;
+        CurrentFilePath = result.Path ?? "Новый файл";
+        Status = "Файл открыт";
+    }
+
+    private async Task SaveFileAsync(Window? window)
+    {
+        if (CurrentFilePath == "Новый файл")
+        {
+            await SaveFileAsAsync(window);
+            return;
+        }
+
+        await _fileService.SaveToPathAsync(CurrentFilePath, SourceText);
+        Status = "Файл сохранен";
+    }
+
+    private async Task SaveFileAsAsync(Window? window)
+    {
+        if (window?.StorageProvider is null) return;
+        var path = await _fileService.SaveFileAsAsync(window.StorageProvider, SourceText);
+        if (path is null) return;
+        CurrentFilePath = path;
+        Status = "Файл сохранен";
+    }
+
+    private void RunAnalysis()
+    {
+        var result = _analyzer.Analyze(SourceText);
+
+        Tokens.Clear();
+        foreach (var token in result.Tokens) Tokens.Add(token);
+
+        Diagnostics.Clear();
+        foreach (var d in result.Diagnostics) Diagnostics.Add(d);
+
+        SyntaxTreeNodes.Clear();
+        if (result.SyntaxTree is not null) SyntaxTreeNodes.Add(new SyntaxTreeNodeViewModel(result.SyntaxTree));
+
+        TreeText = result.TreeText;
+        ErrorCount = result.Diagnostics.Count(x => x.IsError);
+        Status = result.IsSuccess ? "Анализ завершен успешно" : "Анализ завершен с ошибками";
+    }
+
+    private static async Task ShowHelpAsync(Window? owner)
+    {
+        if (owner is null) return;
+        var text = "Введите раздел type языка Pascal и нажмите 'Запустить анализ'.\n\nПример:\ntype TAge = integer;\nTIndex = 1..10;";
+        await ShowDialog(owner, "Руководство пользователя", text);
+    }
+
+    private static async Task ShowAboutAsync(Window? owner)
+    {
+        if (owner is null) return;
+        await ShowDialog(owner, "О программе", "PascalTypeAnalyzer\nКурсовой проект по разработке языкового процессора.");
+    }
+
+    private static async Task ShowDialog(Window owner, string title, string message)
+    {
+        var dlg = new Window
+        {
+            Title = title,
+            Width = 480,
+            Height = 240,
+            Content = new TextBlock { Text = message, TextWrapping = Avalonia.Media.TextWrapping.Wrap, Margin = new Thickness(16) }
+        };
+
+        await dlg.ShowDialog(owner);
+    }
+}

--- a/PascalTypeAnalyzer/Presentation/ViewModels/SyntaxTreeNodeViewModel.cs
+++ b/PascalTypeAnalyzer/Presentation/ViewModels/SyntaxTreeNodeViewModel.cs
@@ -1,0 +1,15 @@
+using PascalTypeAnalyzer.Domain.Syntax;
+
+namespace PascalTypeAnalyzer.Presentation.ViewModels;
+
+public sealed class SyntaxTreeNodeViewModel
+{
+    public string Header { get; }
+    public List<SyntaxTreeNodeViewModel> Children { get; }
+
+    public SyntaxTreeNodeViewModel(SyntaxNode node)
+    {
+        Header = string.IsNullOrWhiteSpace(node.Value) ? node.Name : $"{node.Name}: {node.Value}";
+        Children = node.Children.Select(c => new SyntaxTreeNodeViewModel(c)).ToList();
+    }
+}

--- a/PascalTypeAnalyzer/Presentation/ViewModels/ViewModelBase.cs
+++ b/PascalTypeAnalyzer/Presentation/ViewModels/ViewModelBase.cs
@@ -1,0 +1,5 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace PascalTypeAnalyzer.Presentation.ViewModels;
+
+public abstract partial class ViewModelBase : ObservableObject;

--- a/PascalTypeAnalyzer/Presentation/Views/MainWindow.axaml
+++ b/PascalTypeAnalyzer/Presentation/Views/MainWindow.axaml
@@ -1,0 +1,80 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="clr-namespace:PascalTypeAnalyzer.Presentation.ViewModels"
+        mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="820"
+        x:Class="PascalTypeAnalyzer.Presentation.Views.MainWindow"
+        x:DataType="vm:MainWindowViewModel"
+        Title="PascalTypeAnalyzer" MinWidth="1000" MinHeight="700">
+  <Grid RowDefinitions="Auto,Auto,*,Auto">
+    <Menu Grid.Row="0">
+      <MenuItem Header="Файл"><MenuItem Header="Создать" Command="{Binding NewCommand}"/>
+        <MenuItem Header="Открыть" Command="{Binding OpenCommand}" CommandParameter="{Binding $parent[Window]}"/>
+        <MenuItem Header="Сохранить" Command="{Binding SaveCommand}" CommandParameter="{Binding $parent[Window]}"/>
+        <MenuItem Header="Сохранить как" Command="{Binding SaveAsCommand}" CommandParameter="{Binding $parent[Window]}"/>
+        <Separator/><MenuItem Header="Выход" Command="{Binding ExitCommand}" CommandParameter="{Binding $parent[Window]}"/></MenuItem>
+      <MenuItem Header="Правка">
+        <MenuItem Header="Отменить" Command="{Binding UndoCommand}"/>
+        <MenuItem Header="Вырезать" Command="{Binding CutCommand}"/>
+        <MenuItem Header="Копировать" Command="{Binding CopyCommand}"/>
+        <MenuItem Header="Вставить" Command="{Binding PasteCommand}"/>
+        <MenuItem Header="Выделить все" Command="{Binding SelectAllCommand}"/>
+      </MenuItem>
+      <MenuItem Header="Анализ"><MenuItem Header="Запустить анализ" Command="{Binding AnalyzeCommand}"/></MenuItem>
+      <MenuItem Header="Справка"><MenuItem Header="Руководство пользователя" Command="{Binding HelpCommand}" CommandParameter="{Binding $parent[Window]}"/>
+        <MenuItem Header="О программе" Command="{Binding AboutCommand}" CommandParameter="{Binding $parent[Window]}"/></MenuItem>
+    </Menu>
+
+    <Border Grid.Row="1" Padding="8" BorderBrush="#DDDDDD" BorderThickness="0,0,0,1">
+      <StackPanel Orientation="Horizontal" Spacing="8">
+        <Button Content="Новый" Command="{Binding NewCommand}"/>
+        <Button Content="Открыть" Command="{Binding OpenCommand}" CommandParameter="{Binding $parent[Window]}"/>
+        <Button Content="Сохранить" Command="{Binding SaveCommand}" CommandParameter="{Binding $parent[Window]}"/>
+        <Button Content="▶ Запустить анализ" Command="{Binding AnalyzeCommand}" Background="#2563EB" Foreground="White"/>
+      </StackPanel>
+    </Border>
+
+    <Grid Grid.Row="2" ColumnDefinitions="*,*" Margin="12" ColumnSpacing="12">
+      <Border Grid.Column="0" BorderBrush="#D7D7D7" BorderThickness="1" CornerRadius="8" Padding="10">
+        <TextBox Text="{Binding SourceText}" AcceptsReturn="True" FontFamily="Consolas" FontSize="15"
+                 Watermark="type TAge = integer;" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto"/>
+      </Border>
+      <TabControl Grid.Column="1">
+        <TabItem Header="Дерево">
+          <TreeView ItemsSource="{Binding SyntaxTreeNodes}">
+            <TreeView.ItemTemplate>
+              <TreeDataTemplate ItemsSource="{Binding Children}">
+                <TextBlock Text="{Binding Header}"/>
+              </TreeDataTemplate>
+            </TreeView.ItemTemplate>
+          </TreeView>
+        </TabItem>
+        <TabItem Header="Сообщения">
+          <ListBox ItemsSource="{Binding Diagnostics}"/>
+        </TabItem>
+        <TabItem Header="Лексемы">
+          <DataGrid ItemsSource="{Binding Tokens}" AutoGenerateColumns="False">
+            <DataGrid.Columns>
+              <DataGridTextColumn Header="Тип" Binding="{Binding Type}"/>
+              <DataGridTextColumn Header="Значение" Binding="{Binding Value}"/>
+              <DataGridTextColumn Header="Строка" Binding="{Binding Line}"/>
+              <DataGridTextColumn Header="Столбец" Binding="{Binding Column}"/>
+            </DataGrid.Columns>
+          </DataGrid>
+        </TabItem>
+        <TabItem Header="Текст дерева">
+          <TextBox Text="{Binding TreeText}" IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"/>
+        </TabItem>
+      </TabControl>
+    </Grid>
+
+    <Border Grid.Row="3" Padding="8" BorderBrush="#DDDDDD" BorderThickness="0,1,0,0">
+      <Grid ColumnDefinitions="2*,Auto,*">
+        <TextBlock Text="{Binding Status}"/>
+        <TextBlock Grid.Column="1" Margin="20,0" Text="{Binding ErrorCount, StringFormat='Ошибок: {0}'}"/>
+        <TextBlock Grid.Column="2" HorizontalAlignment="Right" Text="{Binding CurrentFilePath}"/>
+      </Grid>
+    </Border>
+  </Grid>
+</Window>

--- a/PascalTypeAnalyzer/Presentation/Views/MainWindow.axaml.cs
+++ b/PascalTypeAnalyzer/Presentation/Views/MainWindow.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace PascalTypeAnalyzer.Presentation.Views;
+
+public partial class MainWindow : Window
+{
+    public MainWindow() => InitializeComponent();
+}

--- a/PascalTypeAnalyzer/Program.cs
+++ b/PascalTypeAnalyzer/Program.cs
@@ -1,0 +1,15 @@
+using Avalonia;
+
+namespace PascalTypeAnalyzer;
+
+internal static class Program
+{
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+}

--- a/PascalTypeAnalyzer/README.md
+++ b/PascalTypeAnalyzer/README.md
@@ -1,0 +1,46 @@
+# PascalTypeAnalyzer
+
+Кроссплатформенное desktop-приложение на Avalonia UI для лексического и синтаксического анализа раздела описания типов языка Pascal.
+
+## Технологии
+- C# / .NET 8
+- Avalonia UI 11
+- MVVM
+- CommunityToolkit.Mvvm
+
+## Запуск на macOS
+```bash
+dotnet restore
+dotnet run
+```
+
+## Корректные примеры
+```pascal
+type TAge = integer;
+type TIndex = 1..10;
+type TColor = (red, green, blue);
+type TIntArray = array[1..10] of integer;
+type TAge = integer; TIndex = 1..10; TColor = (red, green, blue);
+```
+
+## Некорректные примеры
+```pascal
+type = integer;
+type TAge integer;
+type TRange = 1.10;
+type TArr = array[1..10] integer;
+```
+
+## Архитектура
+- **Domain**: токены, узлы синтаксического дерева, диагностические сообщения.
+- **Application**: Lexer, Parser (recursive descent), AnalyzerService и AnalysisResult.
+- **Infrastructure**: FileService для Open/Save через StorageProvider.
+- **Presentation**: MVVM (ViewModels + Avalonia Views), команды меню/панели инструментов.
+
+## Покрытие требований курсовой
+- Реализованы грамматика, лексический и синтаксический анализ.
+- Добавлен GUI: меню, панель инструментов, редактор, вкладки результатов, строка статуса.
+- Поддержаны команды работы с файлами и запуск анализа.
+- Строится синтаксическое дерево и его текстовое представление.
+- Ошибки отображаются как понятные диагностические сообщения с координатами.
+- Проект кроссплатформенный (macOS/Windows/Linux).


### PR DESCRIPTION
### Motivation
- Provide a cross-platform desktop tool to perform lexical and syntactic analysis of the Pascal `type` section for a coursework project. 
- Separate concerns into layered architecture (Domain / Application / Infrastructure / Presentation) so UI and analysis logic remain decoupled. 
- Offer a user-friendly Avalonia UI (editor, toolbar, menus, result tabs and status bar) to demonstrate analysis results (tokens, diagnostics, syntax tree). 
- Ensure the lexer/parser implement the specified limited Pascal sublanguage and deliver user-oriented diagnostics with error recovery.

### Description
- Project scaffold: added `PascalTypeAnalyzer` .NET 8 Avalonia application with `PascalTypeAnalyzer.csproj`, `Program.cs`, `App.axaml(.cs)` and a Russian `README.md` with run instructions and examples. 
- Domain layer: implemented `Token`, `TokenType`, `SyntaxNode` and `DiagnosticMessage` to hold token metadata, tree structure and human-readable diagnostics. 
- Application layer: implemented `Lexer` (position-aware tokens, `..` -> `Range`, single `.` diagnostic, unknown-character diagnostics) and a recursive-descent `Parser` with dedicated functions for each nonterminal, soft error recovery (synchronizing on `Semicolon`, `TypeKeyword`, `EndOfInput`) and syntax tree construction; added `AnalyzerService` and `AnalysisResult` to orchestrate lexing+parsing and produce a textual tree representation. 
- Infrastructure & Presentation: added `FileService` using Avalonia `StorageProvider` for open/save operations and an MVVM UI (`MainWindowViewModel`, `SyntaxTreeNodeViewModel`, `MainWindow.axaml`) with menu, toolbar, editor (monospace), tabs for Tree / Diagnostics / Tokens / TreeText and a status bar; menu and toolbar commands are bound to ViewModel commands.

### Testing
- Ran `dotnet --version` in the environment and it failed because `dotnet` is not installed here, so `dotnet restore` / `dotnet build` / `dotnet run` could not be executed. 
- Confirmed files and project structure were created successfully by listing the generated sources. 
- No automated unit or integration tests were executed in this environment; runtime verification (restore/build/run) should be performed locally with `dotnet restore` and `dotnet run` on macOS/Windows/Linux.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b273c49108322828c8fad21ce7e28)